### PR TITLE
fix navigationbar and name layout issues in contactDetail scene (#16, #17)

### DIFF
--- a/TesserCube.xcodeproj/project.pbxproj
+++ b/TesserCube.xcodeproj/project.pbxproj
@@ -117,7 +117,6 @@
 		83783388224CC23400F2C0BF /* ContactEditTextCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 83783386224CC23400F2C0BF /* ContactEditTextCell.xib */; };
 		8378338C224DFED100F2C0BF /* SubKeyCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8378338A224DFED100F2C0BF /* SubKeyCardCell.swift */; };
 		8378338D224DFED100F2C0BF /* SubKeyCardCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8378338B224DFED100F2C0BF /* SubKeyCardCell.xib */; };
-		83B03EB122AF57450098B099 /* AppSecret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B03EB022AF57450098B099 /* AppSecret.swift */; };
 		83B93D1F221CE06100F556C0 /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B93D1E221CE06100F556C0 /* Application.swift */; };
 		83B93D22221CEB9800F556C0 /* UserDefaults+AppGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B93D21221CEB9800F556C0 /* UserDefaults+AppGroup.swift */; };
 		83B93D2D221D22FA00F556C0 /* KeyboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B93D2C221D22FA00F556C0 /* KeyboardViewController.swift */; };
@@ -353,7 +352,6 @@
 		83783386224CC23400F2C0BF /* ContactEditTextCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ContactEditTextCell.xib; sourceTree = "<group>"; };
 		8378338A224DFED100F2C0BF /* SubKeyCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubKeyCardCell.swift; sourceTree = "<group>"; };
 		8378338B224DFED100F2C0BF /* SubKeyCardCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SubKeyCardCell.xib; sourceTree = "<group>"; };
-		83B03EB022AF57450098B099 /* AppSecret.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSecret.swift; sourceTree = "<group>"; };
 		83B93D0D221CDC0200F556C0 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Main.strings"; sourceTree = "<group>"; };
 		83B93D0E221CDC0200F556C0 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
 		83B93D1E221CE06100F556C0 /* Application.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Application.swift; sourceTree = "<group>"; };
@@ -853,7 +851,6 @@
 			isa = PBXGroup;
 			children = (
 				8304E994221BF10000122637 /* AppDelegate.swift */,
-				83B03EB022AF57450098B099 /* AppSecret.swift */,
 			);
 			path = "Support Files";
 			sourceTree = "<group>";
@@ -1520,7 +1517,6 @@
 				8313F6912247164000C09C2D /* FloatingAction.swift in Sources */,
 				832146A2223F5FCE008ECC22 /* ContactsListViewController.swift in Sources */,
 				DBBBC195224E29D70080790F /* KeychainMappable.swift in Sources */,
-				83B03EB122AF57450098B099 /* AppSecret.swift in Sources */,
 				DBC7DEC12248D49E00DA4C3E /* ComposeMessageViewModel.swift in Sources */,
 				DB449989228C038E000B7E8A /* SettingsViewController.swift in Sources */,
 				83B93D5D221E6D0B00F556C0 /* UIImage+Color.swift in Sources */,

--- a/TesserCube/Scene/Contacts/ContactDetailViewController.swift
+++ b/TesserCube/Scene/Contacts/ContactDetailViewController.swift
@@ -18,36 +18,36 @@ class ContactDetailViewController: TCBaseViewController {
 
     private var defaultNavigationBarShadowImage: UIImage?
 
-    lazy var backBarButtonItem: UIBarButtonItem = {
-        var rootTitle = ""
-        if let viewControllers = navigationController?.viewControllers, viewControllers.count >= 2 {
-            let previousVC = viewControllers[viewControllers.count - 2]
-            if let previousTitle = previousVC.title {
-                rootTitle = previousTitle
-            }
-        }
+//    lazy var backBarButtonItem: UIBarButtonItem = {
+//        var rootTitle = ""
+//        if let viewControllers = navigationController?.viewControllers, viewControllers.count >= 2 {
+//            let previousVC = viewControllers[viewControllers.count - 2]
+//            if let previousTitle = previousVC.title {
+//                rootTitle = previousTitle
+//            }
+//        }
+//
+//        return UIBarButtonItem(title: rootTitle, style: .plain, target: nil, action: nil)
+//    }()
+//
+//    lazy var standaloneNavigationItems: [UINavigationItem] = {
+//        let rootItem = UINavigationItem(title: backBarButtonItem.title ?? "")
+//        rootItem.backBarButtonItem = backBarButtonItem
+//
+//        let item = UINavigationItem(title: "")
+//        item.rightBarButtonItem = UIBarButtonItem(title: L10n.Common.Button.edit, style: .plain, target: self, action: #selector(ContactDetailViewController.editButtonDidClicked(_:)))
+//
+//        return [rootItem, item]
+//    }()
 
-        return UIBarButtonItem(title: rootTitle, style: .plain, target: nil, action: nil)
-    }()
-
-    lazy var standaloneNavigationItems: [UINavigationItem] = {
-        let rootItem = UINavigationItem(title: backBarButtonItem.title ?? "")
-        rootItem.backBarButtonItem = backBarButtonItem
-
-        let item = UINavigationItem(title: "")
-        item.rightBarButtonItem = UIBarButtonItem(title: L10n.Common.Button.edit, style: .plain, target: self, action: #selector(ContactDetailViewController.editButtonDidClicked(_:)))
-
-        return [rootItem, item]
-    }()
-
-    lazy var navigationBar: UINavigationBar = {
-        let navigationBar = UINavigationBar()
-        navigationBar.delegate = self
-        navigationBar.setBackgroundImage(UIImage(), for: .default)
-        navigationBar.shadowImage = UIImage()
-        navigationBar.items = standaloneNavigationItems
-        return navigationBar
-    }()
+//    lazy var navigationBar: UINavigationBar = {
+//        let navigationBar = UINavigationBar()
+//        navigationBar.delegate = self
+//        navigationBar.setBackgroundImage(UIImage(), for: .default)
+//        navigationBar.shadowImage = UIImage()
+//        navigationBar.items = standaloneNavigationItems
+//        return navigationBar
+//    }()
 
     private var contact: Contact?
 
@@ -137,36 +137,37 @@ class ContactDetailViewController: TCBaseViewController {
         super.configUI()
 
         view.backgroundColor = .white
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: L10n.Common.Button.edit, style: .plain, target: self, action: #selector(ContactDetailViewController.editButtonDidClicked(_:)))
 
-        view.addSubview(navigationBar)
-        navigationBar.snp.makeConstraints { maker in
-            maker.leading.trailing.equalToSuperview()
-            maker.top.equalTo(view.snp.topMargin)
-        }
-
-//        view.addSubview(scrollView)
-//        scrollView.snp.makeConstraints { maker in
-//            maker.leading.trailing.top.bottom.equalToSuperview()
+//        view.addSubview(navigationBar)
+//
+//        navigationBar.snp.makeConstraints { maker in
+//            maker.leading.trailing.equalToSuperview()
+//            maker.top.equalTo(view.snp.topMargin)
 //        }
-
+        
         view.addSubview(topBackgroundView)
-        topBackgroundView.snp.makeConstraints { maker in
-            maker.leading.trailing.equalToSuperview()
-            maker.top.equalToSuperview()
-            maker.height.equalTo(162)
-        }
 
-        topBackgroundView.addSubview(userIdentifierLabel)
         topBackgroundView.addSubview(userNameLabel)
+        topBackgroundView.addSubview(userIdentifierLabel)
+        
+        userNameLabel.snp.makeConstraints { maker in
+            maker.leading.trailing.equalTo(view.layoutMarginsGuide)
+            maker.top.equalToSuperview().offset(79)
+//            maker.bottom.equalTo(userIdentifierLabel.snp.top).offset(-10)
+        }
 
         userIdentifierLabel.snp.makeConstraints { maker in
             maker.leading.trailing.equalTo(view.layoutMarginsGuide)
-            maker.bottom.equalToSuperview().offset(-15)
+            maker.top.equalTo(userNameLabel.snp.bottom).offset(10)
+//            maker.bottom.equalToSuperview().offset(-15)
         }
 
-        userNameLabel.snp.makeConstraints { maker in
-            maker.leading.trailing.equalTo(view.layoutMarginsGuide)
-            maker.bottom.equalTo(userIdentifierLabel.snp.top).offset(-10)
+        topBackgroundView.snp.makeConstraints { maker in
+            maker.leading.trailing.equalToSuperview()
+            maker.top.equalToSuperview()
+//            maker.height.equalTo(162)
+            maker.bottom.equalTo(userIdentifierLabel.snp.bottom).offset(15)
         }
 
         // 1. Fingerprint
@@ -254,7 +255,7 @@ class ContactDetailViewController: TCBaseViewController {
 
         sendMessageButton.addTarget(self, action: #selector(ContactDetailViewController.sendMessageButtonDidClicked(_:)), for: .touchUpInside)
 
-        view.bringSubviewToFront(navigationBar)
+//        view.bringSubviewToFront(navigationBar)
     }
 
 }
@@ -264,7 +265,7 @@ extension ContactDetailViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        navigationController?.setNavigationBarHidden(true, animated: animated)
+//        navigationController?.setNavigationBarHidden(true, animated: animated)
 
         // fix navigation bar hairline bug
         if isPresenting {


### PR DESCRIPTION
for #16 : Use system's original navigation bar instead of customized one. We've hacked into the original navBar to make it looks flat

for #17 : re-arrange the layout constraints to fix the long name label layout issue

BTW the _AppSecret_ file is removed since we do not need it anymore