### PR TITLE
feat: add AirDrop and plaintext file receive supports

### DIFF
--- a/TesserCube.xcodeproj/project.pbxproj
+++ b/TesserCube.xcodeproj/project.pbxproj
@@ -230,6 +230,9 @@
 		DB1169E522E1B63D0099BA25 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = DB1169E722E1B63D0099BA25 /* InfoPlist.strings */; };
 		DB1327152253651C00BD7B98 /* KeyBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1327142253651C00BD7B98 /* KeyBridge.swift */; };
 		DB1327162253651C00BD7B98 /* KeyBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1327142253651C00BD7B98 /* KeyBridge.swift */; };
+		DB1449732313F9CF000FA38E /* BrokenMessageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB63A10D22DF2A5900C2DDA6 /* BrokenMessageViewController.swift */; };
+		DB1449742314F1E1000FA38E /* InterpretActionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB63A10B22DEF75100C2DDA6 /* InterpretActionViewModel.swift */; };
+		DB1449752314F1E4000FA38E /* InterpretActionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB63A0D122DD82EE00C2DDA6 /* InterpretActionViewController.swift */; };
 		DB3B58E22282929700879834 /* WormholdService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3B58E12282929700879834 /* WormholdService.swift */; };
 		DB3B58E52282930600879834 /* WormholdService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3B58E12282929700879834 /* WormholdService.swift */; };
 		DB449989228C038E000B7E8A /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB449988228C038E000B7E8A /* SettingsViewController.swift */; };
@@ -561,6 +564,7 @@
 		C0A9D10AB1612B0483E24D78 /* Pods-TesserCube.debug pgp.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TesserCube.debug pgp.xcconfig"; path = "Pods/Target Support Files/Pods-TesserCube/Pods-TesserCube.debug pgp.xcconfig"; sourceTree = "<group>"; };
 		DB0758A1224493DB0046FBFD /* PGPUserIDTranslator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PGPUserIDTranslator.swift; sourceTree = "<group>"; };
 		DB0758CF224895B40046FBFD /* MessageCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCardCell.swift; sourceTree = "<group>"; };
+		DB0D9F3723152006007C293F /* FileProvider.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FileProvider.framework; path = System/Library/Frameworks/FileProvider.framework; sourceTree = SDKROOT; };
 		DB1169CA22E185640099BA25 /* NotificationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationName.swift; sourceTree = "<group>"; };
 		DB1169D122E187340099BA25 /* TesserCubeComposeAction.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TesserCubeComposeAction.entitlements; sourceTree = "<group>"; };
 		DB1169D322E19ABF0099BA25 /* MessageCardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCardViewController.swift; sourceTree = "<group>"; };
@@ -746,6 +750,7 @@
 		8304E9C5221BF1DD00122637 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				DB0D9F3723152006007C293F /* FileProvider.framework */,
 				DBD638E5227EDC6B00E10BF2 /* JRE.framework */,
 				8304E9C6221BF1DD00122637 /* AuthenticationServices.framework */,
 				829EC06ABC2887E5DB724F5B /* Pods_TesserCube.framework */,
@@ -821,6 +826,7 @@
 				832146AC223F7CCA008ECC22 /* Me */,
 				8313F69922476F4800C09C2D /* Share */,
 				832146A3223F6045008ECC22 /* Base */,
+				DB1449762314F1F1000FA38E /* Action */,
 				832146A7223F65CB008ECC22 /* Common */,
 			);
 			path = Scene;
@@ -912,6 +918,7 @@
 				832146BD223F957B008ECC22 /* MeViewModel.swift */,
 				DB44999B228C248D000B7E8A /* SettingsViewModel.swift */,
 				DB44999D228D3353000B7E8A /* MessageDigitalSignatureSettingsViewModel.swift */,
+				DB63A10B22DEF75100C2DDA6 /* InterpretActionViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1286,6 +1293,15 @@
 			path = MessageCardScene;
 			sourceTree = "<group>";
 		};
+		DB1449762314F1F1000FA38E /* Action */ = {
+			isa = PBXGroup;
+			children = (
+				DB63A0D122DD82EE00C2DDA6 /* InterpretActionViewController.swift */,
+				DB63A10D22DF2A5900C2DDA6 /* BrokenMessageViewController.swift */,
+			);
+			path = Action;
+			sourceTree = "<group>";
+		};
 		DB44998C228C0AAE000B7E8A /* SettingsScene */ = {
 			isa = PBXGroup;
 			children = (
@@ -1319,9 +1335,6 @@
 			isa = PBXGroup;
 			children = (
 				DB63A10822DDD1EC00C2DDA6 /* TesserCubeInterpretAction.entitlements */,
-				DB63A10B22DEF75100C2DDA6 /* InterpretActionViewModel.swift */,
-				DB63A0D122DD82EE00C2DDA6 /* InterpretActionViewController.swift */,
-				DB63A10D22DF2A5900C2DDA6 /* BrokenMessageViewController.swift */,
 				DB63A0D322DD82EE00C2DDA6 /* MainInterface.storyboard */,
 				DB63A12F22E163A700C2DDA6 /* InfoPlist.strings */,
 				DB63A0D622DD82EE00C2DDA6 /* Info.plist */,
@@ -1909,6 +1922,7 @@
 				DB4F300122A11F820003804B /* Contact.swift in Sources */,
 				8313F6932247165F00C09C2D /* FloatingActionGroup.swift in Sources */,
 				832146CD2240B135008ECC22 /* TCBaseViewController.swift in Sources */,
+				DB1449732313F9CF000FA38E /* BrokenMessageViewController.swift in Sources */,
 				DB3B58E22282929700879834 /* WormholdService.swift in Sources */,
 				83783383224CB7F500F2C0BF /* strings.swift in Sources */,
 				DB66FE6A224A330D00D82704 /* String.swift in Sources */,
@@ -1921,6 +1935,7 @@
 				83FF06582250D9DA0003BC0D /* MessageDBAction.swift in Sources */,
 				832146BE223F957B008ECC22 /* MeViewModel.swift in Sources */,
 				DB4CBCAA224F962A00ED6BF0 /* InterpretMessageViewModel.swift in Sources */,
+				DB1449752314F1E4000FA38E /* InterpretActionViewController.swift in Sources */,
 				8378335E2248F1DE00F2C0BF /* HUD.swift in Sources */,
 				DB449990228C13CA000B7E8A /* MessageDigitalSignatureSettings.swift in Sources */,
 				DB44999E228D3353000B7E8A /* MessageDigitalSignatureSettingsViewModel.swift in Sources */,
@@ -1954,6 +1969,7 @@
 				83783371224B384000F2C0BF /* ContactCell.swift in Sources */,
 				832146A5223F604F008ECC22 /* BaseNavigationController.swift in Sources */,
 				8378337F224CB06B00F2C0BF /* ContactEditViewController.swift in Sources */,
+				DB1449742314F1E1000FA38E /* InterpretActionViewModel.swift in Sources */,
 				DBD63FDD229682E400E46FDC /* KeyFactory+TCKey.swift in Sources */,
 				832146B3223F8725008ECC22 /* TCCardView.swift in Sources */,
 				8320AF4A22B64D1C00843FE7 /* IntroWizardViewController.swift in Sources */,

--- a/TesserCube/Application/Coordinator.swift
+++ b/TesserCube/Application/Coordinator.swift
@@ -29,8 +29,7 @@ class Coordinator {
         case writeReply(to: [KeyBridge], from: KeyBridge?)
         case interpretMessage
         case importKey
-        case pasteKey(needPassphrase: Bool)
-        case pasteKeyWith(armoredKey: String, needPassphrase: Bool)
+        case pasteKey(armoredKey: String?, needPassphrase: Bool)
         case createKey
         case pickContacts(delegate: PickContactsDelegate?, selectedContacts: [Contact])
         case contactDetail(contactId: Int64)
@@ -107,12 +106,7 @@ extension Coordinator {
             let vc = ImportKeyViewController()
             vc.hidesBottomBarWhenPushed = true
             return vc
-        case .pasteKey(let needPassphrase):
-            let vc = PasteKeyViewController()
-            vc.needPassphrase = needPassphrase
-            vc.hidesBottomBarWhenPushed = true
-            return vc
-        case let .pasteKeyWith(armoredKey, needPassphrase):
+        case let .pasteKey(armoredKey, needPassphrase):
             let vc = PasteKeyViewController()
             vc.armoredKey = armoredKey
             vc.needPassphrase = needPassphrase
@@ -185,13 +179,13 @@ extension Coordinator {
 
             let hasSecretKey = DMSPGPKeyRing.extractSecretKeyBlock(from: message) != nil
             guard !hasSecretKey else {
-                Coordinator.main.present(scene: .pasteKeyWith(armoredKey: message, needPassphrase: true), from: rootViewController, transition: .modal, completion: nil)
+                Coordinator.main.present(scene: .pasteKey(armoredKey: message, needPassphrase: true), from: rootViewController, transition: .modal, completion: nil)
                 return true
             }
 
             let hasPublicKey = DMSPGPKeyRing.extractPublicKeyBlock(from: message) != nil
             guard !hasPublicKey else {
-                Coordinator.main.present(scene: .pasteKeyWith(armoredKey: message, needPassphrase: false), from: rootViewController, transition: .modal, completion: nil)
+                Coordinator.main.present(scene: .pasteKey(armoredKey: message, needPassphrase: false), from: rootViewController, transition: .modal, completion: nil)
                 return true
             }
 

--- a/TesserCube/Generated/strings.swift
+++ b/TesserCube/Generated/strings.swift
@@ -26,6 +26,8 @@ internal enum L10n {
       internal static let delete = L10n.tr("Localizable", "Common.Button.Delete")
       /// Discard
       internal static let discard = L10n.tr("Localizable", "Common.Button.Discard")
+      /// Done
+      internal static let done = L10n.tr("Localizable", "Common.Button.Done")
       /// Edit
       internal static let edit = L10n.tr("Localizable", "Common.Button.Edit")
       /// OK

--- a/TesserCube/Info.plist
+++ b/TesserCube/Info.plist
@@ -6,6 +6,23 @@
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
 	<string>Tessercube</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeIconFiles</key>
+			<array/>
+			<key>CFBundleTypeName</key>
+			<string>Text File</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.plain-text</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/TesserCube/Resources/en.lproj/Localizable.strings
+++ b/TesserCube/Resources/en.lproj/Localizable.strings
@@ -10,6 +10,7 @@
 "Common.Button.Delete" = "Delete";
 "Common.Button.Edit" = "Edit";
 "Common.Button.Discard" = "Discard";
+"Common.Button.Done" = "Done";
 
 "Common.Label.NameUnknown" = "[Unknown]";
 "Common.Label.NameNone" = "[None]";

--- a/TesserCube/Resources/zh-Hans.lproj/Localizable.strings
+++ b/TesserCube/Resources/zh-Hans.lproj/Localizable.strings
@@ -10,6 +10,7 @@
 "Common.Button.Delete" = "删除";
 "Common.Button.Edit" = "编辑";
 "Common.Button.Discard" = "丢弃";
+"Common.Button.Done" = "完成";
 
 "Common.Label.NameUnknown" = "[未知]";
 "Common.Label.NameNone" = "[无]";

--- a/TesserCube/Resources/zh-Hant.lproj/Localizable.strings
+++ b/TesserCube/Resources/zh-Hant.lproj/Localizable.strings
@@ -10,6 +10,7 @@
 "Common.Button.Delete" = "刪除";
 "Common.Button.Edit" = "編輯";
 "Common.Button.Discard" = "丟棄";
+"Common.Button.Done" = "完成";
 
 "Common.Label.NameUnknown" = "[未知]";
 "Common.Label.NameNone" = "[無]";

--- a/TesserCube/Scene/Action/InterpretActionViewController.swift
+++ b/TesserCube/Scene/Action/InterpretActionViewController.swift
@@ -13,6 +13,7 @@ import MobileCoreServices
 import BouncyCastle_ObjC
 import DMSOpenPGP
 import ConsolePrint
+import os
 
 final class InterpretActionViewController: UIViewController {
 
@@ -21,7 +22,7 @@ final class InterpretActionViewController: UIViewController {
     private lazy var messageCardViewController = MessageCardViewController()
     private lazy var brokenMessageViewController = BrokenMessageViewController()
 
-    private let viewModel = InterpretActionViewModel()
+    let viewModel = InterpretActionViewModel()
 
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
@@ -35,7 +36,9 @@ final class InterpretActionViewController: UIViewController {
 
     private func _init() {
         // Setup Bouncy Castle
+        #if TARGET_IS_EXTENSION
         JavaSecuritySecurity.addProvider(with: OrgBouncycastleJceProviderBouncyCastleProvider())
+        #endif
     }
 
 }
@@ -78,7 +81,7 @@ extension InterpretActionViewController {
                     self.view.addSubview(controller.view)
                     controller.didMove(toParent: self)
 
-                    controller.messageLabel.text = self.viewModel.inputTexts.joined(separator: "\n")
+                    controller.viewModel.message.accept(self.viewModel.inputTexts.joined(separator: "\n"))
                 }
             })
             .disposed(by: disposeBag)
@@ -87,14 +90,21 @@ extension InterpretActionViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
+        #if TARGET_IS_EXTENSION
         extractInputFromExtensionContext()
         NotificationCenter.default.addObserver(self, selector: #selector(InterpretActionViewController.extensionContextCompleteRequest(_:)), name: .extensionContextCompleteRequest, object: nil)
+        #else
+        // delay view model finalize to controller appear
+        // prevent Touch ID & Face ID permission auth alert not display issue
+        viewModel.finalizeInput()
+        #endif
     }
 
 }
 
 extension InterpretActionViewController {
 
+    #if TARGET_IS_EXTENSION
     private func extractInputFromExtensionContext() {
         // check input text
         let providers = extensionContext
@@ -112,12 +122,24 @@ extension InterpretActionViewController {
             let typeIdentifier = kUTTypePlainText as String
             guard provider.hasItemConformingToTypeIdentifier(typeIdentifier) else { continue }
 
+            //swiftlint:disable force_cast
             provider.loadItem(forTypeIdentifier: typeIdentifier, options: nil) { [weak self] text, error in
                 guard let `self` = self else { return }
                 guard error == nil else { return }
-                guard let text = text as? String else { return }
+                switch text {
+                case is String:
+                    os_log("%{public}s[%{public}ld], %{public}s: %{public}s", ((#file as NSString).lastPathComponent), #line, #function, text as! String)
+                    let message = (text as? String) ?? ""
+                    self.viewModel.inputTexts.append(message)
 
-                self.viewModel.inputTexts.append(text)
+                case is URL:
+                    os_log("%{public}s[%{public}ld], %{public}s: %{public}s", ((#file as NSString).lastPathComponent), #line, #function, String(describing: text as! URL))
+                    // Notes: ignore URL if pass in
+                    // [ERROR] Failed to determine whether URL /var/mobile/Containers/Data/Application/78FFF5C0-FDEC-4E26-891B-E525885AD987/Documents/temporary/20190827-170106.txt (s) is managed by a file provider
+                    // InterpretActionViewController.swift[133], extractInputFromExtensionContext(): file:///var/mobile/Containers/Data/Application/BBC162F1-AAF5-431A-AEA1-A1843C24C5C3/Documents/temporary/20190827-165641.txt
+                default:
+                    os_log("%{public}s[%{public}ld], %{public}s: %{public}s", ((#file as NSString).lastPathComponent), #line, #function, String(describing: text))
+                }
 
                 if i == providers.count - 1 {
                     // notify viewModel done
@@ -126,13 +148,16 @@ extension InterpretActionViewController {
                     }
                 }
             }
+            //swiftlint:enable force_cast
         }   // end for … in …
     }
+    #endif
 
 }
 
 extension InterpretActionViewController {
 
+    #if TARGET_IS_EXTENSION
     @objc private func extensionContextCompleteRequest(_ notification: Notification) {
         guard let _ = notification.object as? ComposeMessageViewController,
         let message = notification.userInfo?["message"] as? Message else {
@@ -143,9 +168,14 @@ extension InterpretActionViewController {
         messageCardViewController.viewModel.allowActions.accept([.copy])
         viewModel.composedMessage.accept(message)
     }
+    #endif
 
     @objc private func doneBarButtonItemPressed(_ sender: UIBarButtonItem) {
+        #if TARGET_IS_EXTENSION
         self.extensionContext!.completeRequest(returningItems: self.extensionContext!.inputItems, completionHandler: nil)
+        #else
+        dismiss(animated: true, completion: nil)
+        #endif
     }
 
 }

--- a/TesserCube/Scene/Contacts/ContactsListViewController.swift
+++ b/TesserCube/Scene/Contacts/ContactsListViewController.swift
@@ -133,7 +133,7 @@ class ContactsListViewController: TCBaseViewController {
     @objc
     private func addContactButtonDidClicked(_ sender: UIBarButtonItem) {
         #if !TARGET_IS_EXTENSION
-        Coordinator.main.present(scene: .pasteKey(needPassphrase: false), from: self, transition: .modal, completion: nil)
+        Coordinator.main.present(scene: .pasteKey(armoredKey: nil, needPassphrase: false), from: self, transition: .modal, completion: nil)
         #endif
     }
     

--- a/TesserCube/Scene/Me/KeyManageScene/ImportKeyViewController.swift
+++ b/TesserCube/Scene/Me/KeyManageScene/ImportKeyViewController.swift
@@ -105,7 +105,7 @@ class ImportKeyViewController: TCBaseViewController {
         contentStackView.setCustomSpacing(20, after: pasteKeyButton)
 
         pasteKeyButton.rx.tap.bind { [weak self] in
-                Coordinator.main.present(scene: .pasteKey(needPassphrase: true), from: self)
+                Coordinator.main.present(scene: .pasteKey(armoredKey: nil, needPassphrase: true), from: self)
             }
             .disposed(by: disposeBag)
 

--- a/TesserCube/Scene/Me/KeyManageScene/PasteKeyViewController.swift
+++ b/TesserCube/Scene/Me/KeyManageScene/PasteKeyViewController.swift
@@ -17,6 +17,7 @@ import ConsolePrint
 class PasteKeyViewController: TCBaseViewController {
     
     var needPassphrase: Bool = false
+    var armoredKey: String? = nil
     
     let disposeBag = DisposeBag()
     
@@ -123,42 +124,13 @@ class PasteKeyViewController: TCBaseViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        #if STUB
-//        keyTextView.text = {
-//            let date = Date()
-//            let formatter = DateFormatter()
-//            formatter.dateFormat = "'Test'yyyyMMddHHmm"
-//            let name = formatter.string(from: date)
-//            let key = KeyGenerator().generate(for: "\(name) <tesser@cube.com>", passphrase: "Tessercube")
-//            let armored: String = {
-//                guard let data = try? key.export() else {
-//                    return ""
-//                }
-//                if needPassphrase {
-//                    let pri = Armor.armored(data, as: .secretKey)
-//                    let pub = Armor.armored(data, as: .publicKey)
-//                    return [pri, pub].joined(separator: "")
-//                } else {
-//                    // Warning: should export to .public else Armord string contains private key info
-//                    guard let data = try? key.export(keyType: .public) else {
-//                        return ""
-//                    }
-//                    return Armor.armored(data, as: .publicKey)
-//                }
-//
-//            }()
-//            return armored
-//        }()
-//
-//        if needPassphrase {
-//            passwordTextField.text = "Tessercube"
-//        }
-        #else
-        if hasValidKeyInPasteboard(), keyTextView.text.isEmpty {
+        if let armoredKey = armoredKey {
+            keyTextView.text = armoredKey
+        } else if hasValidKeyInPasteboard(), keyTextView.text.isEmpty {
             keyTextView.text = UIPasteboard.general.string
-            //            showPasteboardConfirmAlert()
+            // showPasteboardConfirmAlert()
         }
-        #endif
+
     }
     
     private func hasValidKeyInPasteboard() -> Bool {

--- a/TesserCube/Share/ShareUtil.swift
+++ b/TesserCube/Share/ShareUtil.swift
@@ -12,9 +12,14 @@ class ShareUtil {
 
     // share public key
     static func share(key: TCKey, from viewController: UIViewController, over view: UIView?) {
-        let armoedKeyString = key.keyRing.publicKeyRing.armored()
-        
-        let vc = UIActivityViewController(activityItems: [armoedKeyString], applicationActivities: [])
+        let armoredKeyString = key.keyRing.publicKeyRing.armored()
+
+        var items: [Any] = [armoredKeyString]
+        if let armoredKeyFileURL = createTempFile(for: armoredKeyString) {
+            items.append(armoredKeyFileURL)
+        }
+
+        let vc = UIActivityViewController(activityItems: items, applicationActivities: [])
         vc.completionWithItemsHandler = { type, result, items, error in
             
         }
@@ -33,9 +38,14 @@ class ShareUtil {
     }
 
     static func export(key: TCKey, from viewController: UIViewController, over view: UIView?) {
-        let armoedKeyString = key.armored
+        let armoredKeyString = key.armored
 
-        let vc = UIActivityViewController(activityItems: [armoedKeyString], applicationActivities: [])
+        var items: [Any] = [armoredKeyString]
+        if let armoredKeyFileURL = createTempFile(for: armoredKeyString) {
+            items.append(armoredKeyFileURL)
+        }
+
+        let vc = UIActivityViewController(activityItems: items, applicationActivities: [])
         vc.completionWithItemsHandler = { type, result, items, error in
 
         }
@@ -54,7 +64,12 @@ class ShareUtil {
     }
     
     static func share(message: String, from viewController: UIViewController, over view: UIView?) {
-        let vc = UIActivityViewController(activityItems: [message], applicationActivities: [])
+        var items: [Any] = [message]
+        if let armoredKeyFileURL = createTempFile(for: message) {
+            items.append(armoredKeyFileURL)
+        }
+
+        let vc = UIActivityViewController(activityItems: items, applicationActivities: [])
         vc.completionWithItemsHandler = { type, result, items, error in
             
         }
@@ -71,4 +86,28 @@ class ShareUtil {
         }
         viewController.present(vc, animated: true)
     }
+
+}
+
+extension ShareUtil {
+
+    static func createTempFile(for text: String) -> NSURL? {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+        let filename: String = {
+            let now = Date()
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyyMMdd-HHmmss"
+            return formatter.string(from: now)
+        }()
+        let fileURL = temporaryDirectory.appendingPathComponent(filename + ".txt")
+        do {
+            try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true, attributes: nil)
+            try text.write(to: fileURL, atomically: true, encoding: .utf8)
+            return fileURL as NSURL
+        } catch {
+            assertionFailure(error.localizedDescription)
+            return nil
+        }
+    }
+
 }

--- a/TesserCube/ViewModel/InterpretActionViewModel.swift
+++ b/TesserCube/ViewModel/InterpretActionViewModel.swift
@@ -49,7 +49,6 @@ final class InterpretActionViewModel: NSObject {
             })
             .disposed(by: disposeBag)
 
-
     }   // end init()
 
 }
@@ -66,4 +65,3 @@ extension InterpretActionViewModel {
     }
 
 }
-


### PR DESCRIPTION
Implement #42 

App now handles income text content and try to:
1. import message as the armored secret key, or
2. import message as the armored public key, or
3. interpret the message as armored PGP message (fail when can not interpret), or
4. prompt user can not handle this message

Also, support AirDrop share and receive:
- share the encrypted armored message
- share public / secret key (passphrase needs)