### PR TITLE
Set LSSupportsOpeningDocumentsInPlace to NO

### DIFF
--- a/TesserCube/Info.plist
+++ b/TesserCube/Info.plist
@@ -52,6 +52,8 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<false/>
 	<key>NSContactsUsageDescription</key>
 	<string>We need to read your contacts records as the recipients of your encrypted messages</string>
 	<key>NSFaceIDUsageDescription</key>


### PR DESCRIPTION
Fix App Store Connect warning ITMS-90737: Missing Document Configuration.

Not bug.