### PR TITLE
Fix NSDiffableDataSourceSnapshot crash issue

### DIFF
--- a/TesserCube/Model/Message.swift
+++ b/TesserCube/Model/Message.swift
@@ -10,7 +10,7 @@ import Foundation
 import GRDB
 
 /// - Note: senderKeyId is lower 16 hex of primary signature key fingerprint. e.g. 58A8B23FAFB1E5C8
-struct Message: Codable, FetchableRecord, MutablePersistableRecord, Equatable {
+struct Message: Codable, FetchableRecord, MutablePersistableRecord {
     var id: Int64?
     var senderKeyId: String         // a.k.a longIdentifier
     var senderKeyUserId: String
@@ -24,15 +24,17 @@ struct Message: Codable, FetchableRecord, MutablePersistableRecord, Equatable {
         id = rowID
     }
     
-    static func == (lhs: Message, rhs: Message) -> Bool {
-        if lhs.encryptedMessage == rhs.encryptedMessage {
-            return true
-        }
-        return lhs.id == rhs.id
-    }
 }
 
-extension Message: Hashable { }
+extension Message: Equatable { }
+
+extension Message: Hashable {
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+    
+}
 
 /// - Note: keyId is lower 16 hex of primary signature key fingerprint. e.g. 58A8B23FAFB1E5C8
 struct MessageRecipient: Codable, FetchableRecord, MutablePersistableRecord {

--- a/TesserCube/Service/ProfileService+Message.swift
+++ b/TesserCube/Service/ProfileService+Message.swift
@@ -14,13 +14,19 @@ import ConsolePrint
 
 extension ProfileService {
     
+    
+    /// Check armored message if already in database
+    /// - Parameter encryptedMessage: armored PGP message
     func interptedMessage(_ encryptedMessage: String) -> Message? {
-        return messages.value.first { $0.encryptedMessage.trimmingCharacters(in: .whitespacesAndNewlines) == encryptedMessage }
+        let trimmedEncryptedMessage = encryptedMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        return messages.value.first {
+            $0.encryptedMessage.trimmingCharacters(in: .whitespacesAndNewlines) == trimmedEncryptedMessage
+        }
     }
     
-    func containsMessage(_ message: Message) -> Bool {
-        return messages.value.contains(message)
-    }
+    // func containsMessage(_ message: Message) -> Bool {
+    //     return messages.value.contains(message)
+    // }
     
     @discardableResult
     func addMessage(_ message: inout Message, recipientKeys: [TCKey]) throws -> Message {
@@ -99,11 +105,9 @@ extension ProfileService {
             guard !message.isEmpty else {
                 throw TCError.interpretError(reason: .emptyMessage)
             }
-            
-            let trimmedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines)
-            
+                        
             // Check if message already interpreted
-            if var existMessage = interptedMessage(trimmedMessage) {
+            if var existMessage = interptedMessage(message) {
                 // If yes, just return the message
                 try existMessage.updateInterpretedDate(Date())
                 return existMessage


### PR DESCRIPTION
https://github.com/DimensionDev/Tessercube-iOS/blob/339ad6a293e86569984eaeaa49eb68cf12e6b6f7/TesserCube/Scene/Messages/MessagesViewScene/MessagesViewController.swift#L339-L367

Fix not unique `Message` item cause the `NSDiffableDataSourceSnapshot` in iOS 13 crash when append items issue.  (Line 353)

The custom `Equatable` protocol returns true when finding the same `encryptedMessage` property. But the internal implement of `NSDiffableDataSourceSnapshot` not only require unique hash value but also the unique `Equalable` protocol. 

Interpret identical messages should just update interpreted date but looks like the legacy code in the old version app could cause the database store duplicated message, a.k.a not unique `Equalable` items. This fix makes the snapshot works when duplicated items append. And due to using auto-generated `Equalable` protocol implement here now. All the messages compare should manually specific property.